### PR TITLE
Endpoints shared the same OrderPlaced consumer

### DIFF
--- a/src/Billing/Consumers/BillOrderConsumer.cs
+++ b/src/Billing/Consumers/BillOrderConsumer.cs
@@ -5,7 +5,7 @@ using Helper;
 using MassTransit;
 using Messages;
 
-public class OrderPlacedConsumer(SimulationEffects simulationEffects) : IConsumer<OrderPlaced>
+public class BillOrderConsumer(SimulationEffects simulationEffects) : IConsumer<OrderPlaced>
 {
     public async Task Consume(ConsumeContext<OrderPlaced> context)
     {

--- a/src/Sales/Consumers/ProcessOrderConsumer.cs
+++ b/src/Sales/Consumers/ProcessOrderConsumer.cs
@@ -5,7 +5,7 @@ using MassTransit;
 using System.Threading.Tasks;
 using Helper;
 
-public class PlaceOrderConsumer(SimulationEffects simulationEffects) : IConsumer<PlaceOrder>
+public class ProcessOrderConsumer(SimulationEffects simulationEffects) : IConsumer<PlaceOrder>
 {
     public async Task Consume(ConsumeContext<PlaceOrder> context)
     {

--- a/src/Shipping/Consumers/PrepareOrderConsumer.cs
+++ b/src/Shipping/Consumers/PrepareOrderConsumer.cs
@@ -5,7 +5,7 @@ using Helper;
 using MassTransit;
 using Messages;
 
-public class OrderPlacedConsumer(SimulationEffects simulationEffects) : IConsumer<OrderPlaced>
+public class PrepareOrderConsumer(SimulationEffects simulationEffects) : IConsumer<OrderPlaced>
 {
     public async Task Consume(ConsumeContext<OrderPlaced> context)
     {

--- a/src/Shipping/Consumers/ShipOrderConsumer.cs
+++ b/src/Shipping/Consumers/ShipOrderConsumer.cs
@@ -5,7 +5,7 @@ using Helper;
 using MassTransit;
 using Messages;
 
-public class OrderBilledConsumer(SimulationEffects simulationEffects) : IConsumer<OrderBilled>
+public class ShipOrderConsumer(SimulationEffects simulationEffects) : IConsumer<OrderBilled>
 {
     public async Task Consume(ConsumeContext<OrderBilled> context)
     {


### PR DESCRIPTION
Endpoints shared the same OrderPlaced consumer causing competing consumer on the OrderPlaced queue. Renamed consumers to represent artificial tasks unique to the endpoint/service.