### PR TITLE
Fix Windows Terminal console text corruption

### DIFF
--- a/src/Billing/Program.cs
+++ b/src/Billing/Program.cs
@@ -4,12 +4,16 @@ using Microsoft.Extensions.Hosting;
 using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
+using System.Text;
+using Microsoft.Extensions.Logging;
 
 class Program
 {
     public static IHostBuilder CreateHostBuilder(string[] args)
     {
+        Console.OutputEncoding = Encoding.UTF8;
         var host = Host.CreateDefaultBuilder(args)
+            .ConfigureLogging(cfg => cfg.ClearProviders())
             .ConfigureServices((hostContext, services) =>
             {
                 services.AddMassTransit(x =>

--- a/src/ClientUI/Program.cs
+++ b/src/ClientUI/Program.cs
@@ -4,12 +4,16 @@ using Microsoft.Extensions.Hosting;
 using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
+using System.Text;
+using Microsoft.Extensions.Logging;
 
 class Program
 {
     public static IHostBuilder CreateHostBuilder(string[] args)
     {
+        Console.OutputEncoding = Encoding.UTF8;
         var host = Host.CreateDefaultBuilder(args)
+            .ConfigureLogging(cfg => cfg.ClearProviders())
             .ConfigureServices((_, services) =>
             {
                 services.AddMassTransit(x =>

--- a/src/Helper/ConsoleHelper.cs
+++ b/src/Helper/ConsoleHelper.cs
@@ -3,16 +3,21 @@
 public class ConsoleHelper
 {
 #pragma warning disable PS0018
-    public static async Task WriteMessageProcessed(DateTime sentTime)
+    public static Task WriteMessageProcessed(DateTime sentTime)
 #pragma warning restore PS0018
     {
-        if (DateTime.UtcNow - sentTime >= TimeSpan.FromSeconds(10))
+        lock (Console.Out)
         {
-            await Console.Out.WriteAsync("\x1b[1;91m■\x1b[0m");
+            if (DateTime.UtcNow - sentTime >= TimeSpan.FromSeconds(10))
+            {
+                Console.Write("■");
+            }
+            else
+            {
+                Console.Write("·");
+            }
         }
-        else
-        {
-            await Console.Out.WriteAsync("·");
-        }
+
+        return Task.CompletedTask;
     }
 }

--- a/src/Sales/Program.cs
+++ b/src/Sales/Program.cs
@@ -4,15 +4,17 @@ namespace Sales;
 using Microsoft.Extensions.Hosting;
 using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
-using System.Security.Cryptography;
 using System.Text;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 
 class Program
 {
     public static IHostBuilder CreateHostBuilder(string[] args)
     {
+        Console.OutputEncoding = Encoding.UTF8;
         var host = Host.CreateDefaultBuilder(args)
+            .ConfigureLogging(cfg => cfg.ClearProviders())
             .ConfigureServices((hostContext, services) =>
             {
                 services.AddMassTransit(x =>

--- a/src/Shipping/Program.cs
+++ b/src/Shipping/Program.cs
@@ -5,12 +5,16 @@ using Microsoft.Extensions.Hosting;
 using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
+using System.Text;
+using Microsoft.Extensions.Logging;
 
 class Program
 {
     public static IHostBuilder CreateHostBuilder(string[] args)
     {
+        Console.OutputEncoding = Encoding.UTF8;
         var host = Host.CreateDefaultBuilder(args)
+            .ConfigureLogging(cfg => cfg.ClearProviders())
             .ConfigureServices((_, services) =>
             {
                 services.AddMassTransit(x =>


### PR DESCRIPTION
Fix console corruption by not using ANSI coloring, seems to corrupt windows terminal