### PR TITLE
Changed structure/usage to adhere to default conventions

### DIFF
--- a/src/Billing/Program.cs
+++ b/src/Billing/Program.cs
@@ -18,6 +18,16 @@ class Program
             {
                 services.AddMassTransit(x =>
                 {
+                    x.AddConsumers(Assembly.GetExecutingAssembly());
+
+                    x.AddConfigureEndpointsCallback((name, cfg) =>
+                    {
+                        if (cfg is IRabbitMqReceiveEndpointConfigurator rmq)
+                        {
+                            rmq.SetQuorumQueue();
+                        }
+                    });
+
                     x.UsingRabbitMq((context, cfg) =>
                     {
                         cfg.Host("localhost", "/", h =>
@@ -28,16 +38,6 @@ class Program
 
                         cfg.ConfigureEndpoints(context);
                     });
-
-                    x.AddConfigureEndpointsCallback((name, cfg) =>
-                    {
-                        if (cfg is IRabbitMqReceiveEndpointConfigurator rmq)
-                        {
-                            rmq.SetQuorumQueue();
-                        }
-                    });
-
-                    x.AddConsumers(Assembly.GetExecutingAssembly());
                 });
 
                 services.AddSingleton<SimulationEffects>();

--- a/src/ClientUI/Program.cs
+++ b/src/ClientUI/Program.cs
@@ -18,6 +18,16 @@ class Program
             {
                 services.AddMassTransit(x =>
                 {
+                    x.AddConsumers(Assembly.GetExecutingAssembly());
+
+                    x.AddConfigureEndpointsCallback((name, cfg) =>
+                    {
+                        if (cfg is IRabbitMqReceiveEndpointConfigurator rmq)
+                        {
+                            rmq.SetQuorumQueue();
+                        }
+                    });
+
                     x.UsingRabbitMq((context, cfg) =>
                     {
                         cfg.Host("localhost", "/", h =>
@@ -28,20 +38,10 @@ class Program
 
                         cfg.ConfigureEndpoints(context);
                     });
-
-                    x.AddConfigureEndpointsCallback((name, cfg) =>
-                    {
-                        if (cfg is IRabbitMqReceiveEndpointConfigurator rmq)
-                        {
-                            rmq.SetQuorumQueue();
-                        }
-                    });
-
-                    x.AddConsumers(Assembly.GetExecutingAssembly());
                 });
 
                 services.AddSingleton<SimulatedCustomers>();
-                services.AddHostedService(p => p.GetRequiredService<SimulatedCustomers>());
+                services.AddHostedService<SimulatedCustomers>();
                 services.AddHostedService<ConsoleBackgroundService>();
             });
 

--- a/src/Messages/OrderBilled.cs
+++ b/src/Messages/OrderBilled.cs
@@ -1,6 +1,6 @@
 ﻿namespace Messages;
 
-public class OrderBilled
+public record OrderBilled
 {
-    public string OrderId { get; set; }
+    public string OrderId { get; init; }
 }

--- a/src/Messages/OrderPlaced.cs
+++ b/src/Messages/OrderPlaced.cs
@@ -1,6 +1,6 @@
 ﻿namespace Messages;
 
-public class OrderPlaced
+public record OrderPlaced
 {
-    public string OrderId { get; set; }
+    public string OrderId { get; init; }
 }

--- a/src/Messages/PlaceOrder.cs
+++ b/src/Messages/PlaceOrder.cs
@@ -1,6 +1,6 @@
 ﻿namespace Messages;
 
-public class PlaceOrder
+public record PlaceOrder
 {
-    public string OrderId { get; set; }
+    public string OrderId { get; init; }
 }

--- a/src/Sales/Program.cs
+++ b/src/Sales/Program.cs
@@ -19,6 +19,16 @@ class Program
             {
                 services.AddMassTransit(x =>
                 {
+                    x.AddConsumers(Assembly.GetExecutingAssembly());
+
+                    x.AddConfigureEndpointsCallback((name, cfg) =>
+                    {
+                        if (cfg is IRabbitMqReceiveEndpointConfigurator rmq)
+                        {
+                            rmq.SetQuorumQueue();
+                        }
+                    });
+
                     x.UsingRabbitMq((context, cfg) =>
                     {
                         cfg.Host("localhost", "/", h =>
@@ -28,16 +38,6 @@ class Program
                         });
 
                         cfg.ConfigureEndpoints(context);
-                    });
-
-                    x.AddConsumers(Assembly.GetExecutingAssembly());
-
-                    x.AddConfigureEndpointsCallback((name, cfg) =>
-                    {
-                        if (cfg is IRabbitMqReceiveEndpointConfigurator rmq)
-                        {
-                            rmq.SetQuorumQueue();
-                        }
                     });
                 });
 

--- a/src/Shipping/Program.cs
+++ b/src/Shipping/Program.cs
@@ -19,6 +19,16 @@ class Program
             {
                 services.AddMassTransit(x =>
                 {
+                    x.AddConsumers(Assembly.GetExecutingAssembly());
+
+                    x.AddConfigureEndpointsCallback((name, cfg) =>
+                    {
+                        if (cfg is IRabbitMqReceiveEndpointConfigurator rmq)
+                        {
+                            rmq.SetQuorumQueue();
+                        }
+                    });
+
                     x.UsingRabbitMq((context, cfg) =>
                     {
                         cfg.Host("localhost", "/", h =>
@@ -28,16 +38,6 @@ class Program
                         });
 
                         cfg.ConfigureEndpoints(context);
-                    });
-
-                    x.AddConsumers(Assembly.GetExecutingAssembly());
-
-                    x.AddConfigureEndpointsCallback((name, cfg) =>
-                    {
-                        if (cfg is IRabbitMqReceiveEndpointConfigurator rmq)
-                        {
-                            rmq.SetQuorumQueue();
-                        }
                     });
                 });
 


### PR DESCRIPTION
Subtle changes, but inline with how MassTransit is expected to be configured. Also changed the producer to use an async scope with `IPublishEndpoint` since publishing with the bus is discouraged.
