### PR TITLE
Remove unnecessary mention of ServicePulse

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This showcase consists of 4 processes hosting MassTransit message producers and 
 
 ## Launching the Showcase in Docker
 
-The showcase requires a connection to a broker (by default RabbitMQ), [ServiceControl](https://hub.docker.com/r/particular/servicecontrol) container, [ServicePulse](https://hub.docker.com/r/particular/servicepulse) container and the [MassTransit Connector for ServiceControl](https://hub.docker.com/r/particular/servicecontrol-masstransit-connector) container.  
 To help getting started we have created a few docker compose files that orchestrate all this setup for you.
 
 Run the docker command below from the `src` folder in a terminal.

--- a/README.md
+++ b/README.md
@@ -73,19 +73,17 @@ Navigate to http://localhost:61335/ to see the UI.
 
 Click `Run Scenario` to send some messages and generate some simulated failures.
 
-## Handling failures with the Particular Platform
-
-### Inspecting failures
+## Managing errors
 
 Navigate to [http://localhost:9090](http://localhost:9090) in a new tab, or click the `View Failures` button, to see the details on failures ingested by the platform.
 
-![Service Pulse Dashboard](docs/service-pulse-dashboard-failed-messages.png "Message processing errors summary view")
+![Dashboard](docs/service-pulse-dashboard-failed-messages.png "Message processing errors summary view")
 
 ### Scheduling message reprocessing
 
 Click on the "Failed Messages" button at the top of the page to see all failed messages ingested by the platform, grouped by the exception type and stack trace.
 
-![Service Pulse Failed Messages](docs/service-pulse-dashboard-failed-messages-groups.png "Failed messages grouping")
+![Failed Messages](docs/service-pulse-dashboard-failed-messages-groups.png "Failed messages grouping")
 
 Drill into an existing group to see the list of individual processing failures. Clicking on any of the rows in the list shows detailed information of a given failed message in the headers and message body tabs.
 
@@ -94,7 +92,7 @@ A failed message can be scheduled for reprocessing by clicking the `Retry messag
 > [!NOTE]
 > It may take several seconds after retrying a message for it to appear again in the consumer's input queue
 
-![Service Pulse Failed Message View](docs/service-pulse-failed-message-view.png "Failed message details view")
+![Failed Message View](docs/service-pulse-failed-message-view.png "Failed message details view")
 
 ### Editing messages before reprocessing
 
@@ -109,11 +107,11 @@ Navigate to the `Message Body` tab and change some of the contents of the messag
 
 ### Viewing retries
 
-Return to the showcase UI to see that the retries have now been successfully handled.
+Return to the Showcase UI to see that the retries have now been successfully handled.
 
 ### Troubleshooting
 
 Having issues?
 
 - Check logs in docker. Ensure that there are no port clashes with existing containers or services on your machine.
-- Ask any questions on [our forum](https://discuss.particular.net/tag/masstransit)
+- Ask any questions you may have on [our forum](https://discuss.particular.net/tag/masstransit)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This showcase consists of 4 processes hosting MassTransit message producers and 
 
 To help getting started we have created a few docker compose files that orchestrate all this setup for you.
 
-Run the docker command below from the `src` folder in a terminal.
+* First, make sure you've pulled down the repository to your machine.
+* Second, open a terminal and navigate to the `src` folder in your local copy of the repository.
+* Third, run the following command:
 
 ```cmd
 docker compose -p particular-platform-showcase -f docker-compose-base.yml -f compose-rabbitmq.yml --env-file rabbit.env up -d

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Run the solution to start the demo.
 
 ## Opening the showcase UI
 
-Navigate to http://localhost:61335/ to see the UI. Click `Run Scenario` to start the showcase scenario and generate some simulated message handling failures.
+Navigate to http://localhost:61335/ to see the UI.
+
+Click `Run Scenario` to send some messages and generate some simulated failures.
 
 ## Handling failures with the Particular Platform
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Click `Run Scenario` to send some messages and generate some simulated failures.
 
 ### Inspecting failures
 
-Navigate to [http://localhost:9090](http://localhost:9090) in a new tab, or click the `View in ServicePulse` button, to see the details on failures ingested by the platform.
+Navigate to [http://localhost:9090](http://localhost:9090) in a new tab, or click the `View Failures` button, to see the details on failures ingested by the platform.
 
 ![Service Pulse Dashboard](docs/service-pulse-dashboard-failed-messages.png "Message processing errors summary view")
 

--- a/README.md
+++ b/README.md
@@ -114,4 +114,9 @@ Return to the Showcase UI to see that the retries have now been successfully han
 Having issues?
 
 - Check logs in docker. Ensure that there are no port clashes with existing containers or services on your machine.
+- Check that all containers are running:
+  - RabbitMQ
+  - [ServicePulse](https://hub.docker.com/r/particular/servicepulse)
+  - [ServiceControl](https://hub.docker.com/r/particular/servicecontrol)
+  - [MassTransit Connector for ServiceControl](https://hub.docker.com/r/particular/servicecontrol-masstransit-connector)
 - Ask any questions you may have on [our forum](https://discuss.particular.net/tag/masstransit)

--- a/src/frontend/src/components/BillingEndpoint.vue
+++ b/src/frontend/src/components/BillingEndpoint.vue
@@ -128,7 +128,7 @@ function toggleFailOnRetries() {
         target="_blank"
         :href="`http://localhost:9090/#/failed-messages/message/${message.messageViewId}`"
       >
-        View failure in ServicePulse
+        View failure details
       </a>
     </template>
     <template v-else-if="isOrderBilled(message.message)">

--- a/src/frontend/src/components/ClientEndpoint.vue
+++ b/src/frontend/src/components/ClientEndpoint.vue
@@ -71,7 +71,7 @@ async function runScenario() {
       </button>
       <a target="_blank" href="http://localhost:9090/#/failed-messages/">
         <button type="button" class="secondary view-servicepulse">
-          View Failures in ServicePulse
+          View Failures
         </button>
       </a>
       <span class="note">

--- a/src/frontend/src/components/SalesEndpoint.vue
+++ b/src/frontend/src/components/SalesEndpoint.vue
@@ -112,7 +112,7 @@ function toggleFailOnRetries() {
       <a
         target="_blank"
         :href="`http://localhost:9090/#/failed-messages/message/${message.messageViewId}`"
-        >View failure in ServicePulse</a
+        >View failure details</a
       >
     </template>
     <template v-else-if="isOrderPlaced(message.message)">

--- a/src/frontend/src/components/ShippingEndpoint.vue
+++ b/src/frontend/src/components/ShippingEndpoint.vue
@@ -149,7 +149,7 @@ function toggleFailOnRetries() {
         target="_blank"
         :href="`http://localhost:9090/#/failed-messages/message/${message.messageViewId}`"
       >
-        View failure in ServicePulse
+        View failure details
       </a>
     </template>
     <template v-else>


### PR DESCRIPTION
As we don't want people to focus on names like ServicePulse or ServiceControl unnecessarily, preferring to keep the focus on the Service Platform.